### PR TITLE
Update Top PyPI Packages URL

### DIFF
--- a/getpypi1000.py
+++ b/getpypi1000.py
@@ -1,7 +1,7 @@
 import subprocess
 import json
 
-curlCmd = ['curl', 'https://raw.githubusercontent.com/hugovk/top-pypi-packages/master/top-pypi-packages-30-days.json', '-o' '/tmp/pypi-packages.json']
+curlCmd = ['curl', 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json', '-o' '/tmp/pypi-packages.json']
 subprocess.run(curlCmd)
 
 with open("/tmp/pypi-packages.json", "r") as packages:


### PR DESCRIPTION
The repo has just switched from `master` to `main` (https://github.com/hugovk/top-pypi-packages/pull/22), and whilst GitHub is redirecting or serving something at the old one, it's also best to use the one served via GitHub Pages, for example in case the Git directory structure changes in the future.

Also fetch the minimised file, it's a bit smaller (279K -> 249K).